### PR TITLE
feat: add Cerebras AI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Replace your API domain with the domain of the proxy deployed on your server. Fo
 - xAI:
   - from `https://api.xai.ai`
   - to `https://your-proxy/xai`
+- Cerebras:
+  - from `https://api.cerebras.ai`
+  - to `https://your-proxy/cerebras`
  
 ## Hosted by ChatWise
 

--- a/main.ts
+++ b/main.ts
@@ -89,6 +89,10 @@ const proxies: { pathSegment: string; target: string; orHostname?: string }[] =
       target: "https://api.x.ai",
     },
     {
+      pathSegment: "cerebras",
+      target: "https://api.cerebras.ai",
+    },
+    {
       pathSegment: "googleapis-cloudcode-pa",
       target: "https://cloudcode-pa.googleapis.com",
     },


### PR DESCRIPTION
Adds support for Cerebras AI in the ai-proxy service.

## Changes
- Added Cerebras proxy configuration to route `/cerebras/*` to `https://api.cerebras.ai`
- Updated README.md with Cerebras usage example
- Follows same pattern as other AI provider integrations

Closes #7

Generated with [Claude Code](https://claude.ai/code)